### PR TITLE
added useLocalStorageHook

### DIFF
--- a/src/hooks/useLocalStorage.js
+++ b/src/hooks/useLocalStorage.js
@@ -1,0 +1,26 @@
+import { useState } from 'react';
+
+const useLocalStorage = (propertyName, defaultValue) => {
+    const [ storedValue, setStoredValue ] = useState(() => {
+        try {
+            const value = window.localStorage.getItem(propertyName);
+            if(value){
+                return JSON.parse(value);
+            }else{
+                window.localStorage.setItem(propertyName, JSON.stringify(defaultValue));
+                return defaultValue;
+            }
+        } catch (error){
+            return defaultValue;
+        }
+    })
+    const setValue = newValue => {
+        try{
+            window.localStorage.setItem(propertyName, JSON.stringify(newValue));
+        } catch (error){}
+        setStoredValue(newValue)
+    };
+
+    return [storedValue, setValue]
+}
+export default useLocalStorage;


### PR DESCRIPTION
Added useLocalStorage hook, to work with local storage and remember if the user already click the 'visit' button on the welcome page on a session.
Expected behavior:
load/reload base url: Cover element display to ask the use if he/she wants to visit
navigate the site and come back to welcome page: Cover element does not display as the user already choose to pay a visit.